### PR TITLE
Add toltec repo and use a recent wget during installation

### DIFF
--- a/entware_install.sh
+++ b/entware_install.sh
@@ -39,12 +39,12 @@ echo "Info: Checking for prerequisites and creating folders..."
 if [ -d /opt ]
 then
     echo "Error: Folder /opt exists! Quitting..."
-    exit
+    exit 1
 else
     if [ -d /home/root/.entware ]
     then
         echo "Error: Folder /home/root/.entware exists! Quitting..."
-        exit
+        exit 1
     else
         mkdir /opt
         # mount /opt in /home for more storage space

--- a/entware_install.sh
+++ b/entware_install.sh
@@ -148,7 +148,7 @@ echo "INFO: Adding repo for reMarkable software"
 echo 'src/gz toltec https://toltec.delab.re/stable' >> /opt/etc/opkg.conf
 /opt/bin/opkg update
 echo "INFO: Install wget (onboard wget is fairly old)"
-/opt/bin/opkg install wget
+/opt/bin/opkg install wget ca-certificates
 
 # No more needed
 rm /home/root/.wget_bin -rf

--- a/entware_install.sh
+++ b/entware_install.sh
@@ -56,7 +56,7 @@ fi
 if [ ! -d /home/root/.cache/wget_bin ]
 then
     # Bootstrap a current version of wget
-    WGET_BINARIES_PATH='http://static.cosmos-ink.net/remarkable/artifacts'
+    WGET_BINARIES_PATH='http://github.com/LinusCDE/wget-remarkable-pipeline/releases/download/job254'
     WGET_BINARIES_FILENAME='wget-remarkable-pipeline_job245_wget1.20.3.zip'
     WGET_BINARIES_SHA256='84185a5934e34e25794d439c78dc9f1590e4df12fbf369236f6a8749bf14d67f'
 

--- a/entware_install.sh
+++ b/entware_install.sh
@@ -24,9 +24,9 @@ cleanup() {
         rm /etc/systemd/system/opt.mount
     fi
 
-    if [ -e /home/root/.wget_bin ]
+    if [ -e /home/root/.cache/wget_bin ]
     then
-        rm /home/root/.wget_bin -rf
+        rm /home/root/.cache/wget_bin -rf
     fi
 }
 trap cleanup ERR
@@ -53,7 +53,7 @@ else
     fi
 fi
 
-if [ ! -d /home/root/.wget_bin ]
+if [ ! -d /home/root/.cache/wget_bin ]
 then
     # Bootstrap a current version of wget
     WGET_BINARIES_PATH='http://static.cosmos-ink.net/remarkable/artifacts'
@@ -68,28 +68,28 @@ then
         exit 1
     fi
 
-    # Ensure to /home/root/.wget_bin exists and is empty
-    if [ -d /home/root/.wget_bin ]
+    # Ensure to /home/root/.cache/wget_bin exists and is empty
+    if [ -d /home/root/.cache/wget_bin ]
     then
-        rm -rf /home/root/.wget_bin/*
+        rm -rf /home/root/.cache/wget_bin/*
     else
-        mkdir /home/root/.wget_bin
+        mkdir -p /home/root/.cache/wget_bin
     fi
-    # Unzip to /home/root/.wget_bin and remove downloaded file
-    unzip "/home/root/$WGET_BINARIES_FILENAME" -d /home/root/.wget_bin -q
+    # Unzip to /home/root/.cache/wget_bin and remove downloaded file
+    unzip "/home/root/$WGET_BINARIES_FILENAME" -d /home/root/.cache/wget_bin -q
     rm "/home/root/$WGET_BINARIES_FILENAME"
 
-    cat > /home/root/.wget_bin/wget <<EOF
+    cat > /home/root/.cache/wget_bin/wget <<EOF
 #!/bin/sh
-LD_LIBRARY_PATH="/home/root/.wget_bin/dist" /home/root/.wget_bin/dist/wget \$@
+LD_LIBRARY_PATH="/home/root/.cache/wget_bin/dist" /home/root/.cache/wget_bin/dist/wget \$@
 EOF
 
-    chmod +x /home/root/.wget_bin/wget
+    chmod +x /home/root/.cache/wget_bin/wget
 fi
 
 # Ensure this binary is used
-if [ `which wget` != '/home/root/.wget_bin/wget' ]; then
-  PATH="/home/root/.wget_bin:$PATH"
+if [ `which wget` != '/home/root/.cache/wget_bin/wget' ]; then
+  PATH="/home/root/.cache/wget_bin:$PATH"
 fi
 
 # create systemd mount unit to mount over /opt on reboot
@@ -150,7 +150,7 @@ echo "Info: Basic packages installation..."
 /opt/bin/opkg install entware-opt wget ca-certificates
 
 # No more needed
-rm /home/root/.wget_bin -rf
+rm /home/root/.cache/wget_bin -rf
 
 # Fix for multiuser environment
 chmod 777 /opt/tmp

--- a/entware_install.sh
+++ b/entware_install.sh
@@ -141,14 +141,13 @@ ln -s ld-2.27.so $DLOADER
 ln -s libc-2.27.so libc.so.6
 ln -s libpthread-2.27.so libpthread.so.0
 
-echo "Info: Basic packages installation..."
-/opt/bin/opkg update
-/opt/bin/opkg install entware-opt
 echo "INFO: Adding repo for reMarkable software"
 echo 'src/gz toltec https://toltec.delab.re/stable' >> /opt/etc/opkg.conf
+
+sed -i 's|http://|https://|g' /opt/etc/opkg.conf
+echo "Info: Basic packages installation..."
 /opt/bin/opkg update
-echo "INFO: Install wget (onboard wget is fairly old)"
-/opt/bin/opkg install wget ca-certificates
+/opt/bin/opkg install entware-opt wget ca-certificates
 
 # No more needed
 rm /home/root/.wget_bin -rf

--- a/entware_install.sh
+++ b/entware_install.sh
@@ -149,9 +149,6 @@ echo "Info: Basic packages installation..."
 /opt/bin/opkg update
 /opt/bin/opkg install entware-opt wget ca-certificates
 
-# No more needed
-rm /home/root/.cache/wget_bin -rf
-
 # Fix for multiuser environment
 chmod 777 /opt/tmp
 

--- a/entware_install.sh
+++ b/entware_install.sh
@@ -85,7 +85,11 @@ LD_LIBRARY_PATH="/home/root/.wget_bin/dist" /home/root/.wget_bin/dist/wget \$@
 EOF
 
     chmod +x /home/root/.wget_bin/wget
-    PATH="/home/root/.wget_bin:$PATH"
+fi
+
+# Ensure this binary is used
+if [ `which wget` != '/home/root/.wget_bin/wget' ]; then
+  PATH="/home/root/.wget_bin:$PATH"
 fi
 
 # create systemd mount unit to mount over /opt on reboot

--- a/entware_install.sh
+++ b/entware_install.sh
@@ -83,12 +83,8 @@ then
 #!/bin/sh
 LD_LIBRARY_PATH="/home/root/.wget_bin/dist" /home/root/.wget_bin/dist/wget \$@
 EOF
+
     chmod +x /home/root/.wget_bin/wget
-
-    # Optional env file
-    #echo 'PATH="/home/root/.wget_bin/dist:$PATH' > "$WGET_DEST_DIR/env"
-    #chmod +x "$WGET_DEST_DIR/env"
-
     PATH="/home/root/.wget_bin:$PATH"
 fi
 


### PR DESCRIPTION
Hi,

recently there is a lot of organizing around packing community mods/software for the reMarkable to make them more easily accessible. It is still very much a WIP, but [Mattéo Delabre](https://github.com/matteodelabre) did some amazing work in his [toltec](https://github.com/matteodelabre/toltec) which he hosts the packages that are created on the page I referenced. I asked him for permission and he is ok with his repo being added here.

(There is also an updated version of draft being worked on called [oxide](https://github.com/Eeems/oxide), which allows for more flexibility for adding entries to it. New packages to the toltec repo are encouraged to have such entries to make oxide and opkg with toltec the ultimate experience for the reMarkable. A GUI for package management is also in discussion.)

I also added a newer compiled version of wget to be used during installation. The Onboard wget binary is fairly old and doesn't even support some https servers anymore (tls error 80: internal error, and certs cant be verified). This addition makes it possible to use https for most downloads during installation and then installs wget from opkg (which is also recent) to do the job from then on (opkg used wget to download packages and Package.gz updates).

Additionally, to complement the above, I reversed the PATH in the suggestion to actually prefer opkg's wget over the onboard one.

See the commits descriptions for more specific info on the changes.