### PR TITLE
Add reenable hooks

### DIFF
--- a/entware_reenable.sh
+++ b/entware_reenable.sh
@@ -27,6 +27,17 @@ EOF
 systemctl daemon-reload
 systemctl enable opt.mount
 
-
 echo ""
 echo "Info: Entware has been re-enabled."
+
+# Hooks
+HOOKS_DIR=/opt/etc/remarkable_entware_reenable.d
+if [ -d $HOOKS_DIR ]; then
+  echo "Info: Running hooks..."
+  for hook in $HOOKS_DIR/*; do
+    if ! $hook; then
+      echo "Hook failed:" `basename "$hook"` >&2
+    fi
+  done
+  echo "Info: Hooks completed"
+fi


### PR DESCRIPTION
Hi,

this PR is kinda building upon PR #7 .

Since the already packaged launchers add themselves a systemd services, they need an opportunity to get reenabled when the reMarkable gets an update.

This PR just runs all the scripts found in a specific folder when doing the reenable to give packages the opportunity should they have added a script there.