### PR TITLE
Remove Toltec

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a modified installer for [Entware](https://github.com/Entware/Entware), a lightweight package manager and software repo for embedded devices.
 
-If you'd like to install reMarkable specific packages, you should install [Toltec](https://github.com/toltec-dev/toltec) instead,. which includes the Entware repositories.
+If you'd like to install reMarkable specific packages, you should install [Toltec](https://github.com/toltec-dev/toltec) instead, which includes the Entware repositories.
 
 See a list of available packages [here](http://bin.entware.net/armv7sf-k3.2/) and [here](https://toltec-dev.org/stable/).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # reMarkable Entware
 
-This is a modified installer for [Entware](https://github.com/Entware/Entware), a lightweight package manager and software repo for embedded devices.  Includes [Toltec](https://github.com/toltec-dev/toltec).
+This is a modified installer for [Entware](https://github.com/Entware/Entware), a lightweight package manager and software repo for embedded devices.
+
+If you'd like to install reMarkable specific packages, you should install [Toltec](https://github.com/toltec-dev/toltec) instead,. which includes the Entware repositories.
 
 See a list of available packages [here](http://bin.entware.net/armv7sf-k3.2/) and [here](https://toltec-dev.org/stable/).
 

--- a/install.sh
+++ b/install.sh
@@ -109,8 +109,6 @@ ln -s ld-2.27.so $DLOADER
 ln -s libc-2.27.so libc.so.6
 ln -s libpthread-2.27.so libpthread.so.0
 
-echo 'src/gz toltec https://toltec.delab.re/stable' >> /opt/etc/opkg.conf
-
 /opt/bin/opkg update
 /opt/bin/opkg install entware-opt wget ca-certificates
 

--- a/install.sh
+++ b/install.sh
@@ -110,7 +110,7 @@ ln -s libc-2.27.so libc.so.6
 ln -s libpthread-2.27.so libpthread.so.0
 
 /opt/bin/opkg update
-/opt/bin/opkg install entware-opt wget ca-certificates
+/opt/bin/opkg install entware-opt wget wget-ssl ca-certificates
 
 sed -i 's|http://|https://|g' /opt/etc/opkg.conf
 


### PR DESCRIPTION
Remove toltec as it's not supported to install it through this script. Instead add instructions to install using toltec instead if required.

Partially resolves #17 
Potentially resolves #15 