### PR TITLE
Corrected install.sh s.t. opkg update and install commands work

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a modified installer for [Entware](https://github.com/Entware/Entware), a lightweight package manager and software repo for embedded devices.
 
-If you'd like to install reMarkable specific packages, you should install [Toltec](https://github.com/toltec-dev/toltec) instead, which includes the Entware repositories.
+If you'd like to install reMarkable specific packages, you should install [Toltec](https://github.com/toltec-dev/toltec) instead, which includes the Entware repositories. WARNING: you may softbrick your device when installing Toltec if Toltec does not support your current version.
 
 See a list of available packages [here](http://bin.entware.net/armv7sf-k3.2/) and [here](https://toltec-dev.org/stable/).
 

--- a/install.sh
+++ b/install.sh
@@ -112,6 +112,9 @@ ln -s libpthread-2.27.so libpthread.so.0
 /opt/bin/opkg update
 /opt/bin/opkg install entware-opt wget wget-ssl ca-certificates
 
+# switch wget w/ ssl and https
+rm /opt/bin/wget
+ln -s /opt/libexec/wget-ssl /opt/bin/wget
 sed -i 's|http://|https://|g' /opt/etc/opkg.conf
 
 # Fix for multiuser environment

--- a/install.sh
+++ b/install.sh
@@ -112,7 +112,7 @@ ln -s libpthread-2.27.so libpthread.so.0
 /opt/bin/opkg update
 /opt/bin/opkg install entware-opt wget wget-ssl ca-certificates
 
-# switch wget w/ ssl and https
+# switch to wget compiled w/ ssl for https
 rm /opt/bin/wget
 ln -s /opt/libexec/wget-ssl /opt/bin/wget
 sed -i 's|http://|https://|g' /opt/etc/opkg.conf


### PR DESCRIPTION
`install.sh` previously switched installation and updating protocols from `http` to `https` without also adjusting `wget` to a version compiled with `ssl`. As a result, calls to `opkg update` and `opkg install` failed with a `wget` error code 1.

The fix is to remove `/opt/bin/wget` and simlink `wget-ssl` prior to switching from `http` to `https` in the `opkg.conf` file. 